### PR TITLE
fix: loosen types

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "types": "./types/index.d.ts",
   "devDependencies": {
+    "@typescript-eslint/types": "^8.2.0",
     "@vitest/ui": "^2.1.1",
     "acorn": "^8.11.3",
     "acorn-typescript": "^1.4.13",
@@ -37,8 +38,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@jridgewell/sourcemap-codec": "^1.4.15",
-    "@typescript-eslint/types": "^8.2.0"
+    "@jridgewell/sourcemap-codec": "^1.4.15"
   },
   "packageManager": "pnpm@9.8.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,10 +11,10 @@ importers:
       '@jridgewell/sourcemap-codec':
         specifier: ^1.4.15
         version: 1.5.0
+    devDependencies:
       '@typescript-eslint/types':
         specifier: ^8.2.0
         version: 8.2.0
-    devDependencies:
       '@vitest/ui':
         specifier: ^2.1.1
         version: 2.1.1(vitest@2.1.1)

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
 }
 
 /**
- * @param {TSESTree.Node} node
+ * @param {{ type: 'string', [key: string]: any }} node
  * @param {PrintOptions} opts
  * @returns {{ code: string, map: any }} // TODO
  */
@@ -41,7 +41,7 @@ export function print(node, opts = {}) {
 		multiline: false
 	};
 
-	handle(node, state);
+	handle(/** @type {TSESTree.Node} */ (/** @type {any} */ (node)), state);
 
 	/** @typedef {[number, number, number, number]} Segment */
 

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,7 @@ if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
 }
 
 /**
- * @param {{ type: 'string', [key: string]: any }} node
+ * @param {{ type: string, [key: string]: any }} node
  * @param {PrintOptions} opts
  * @returns {{ code: string, map: any }} // TODO
  */
@@ -25,7 +25,6 @@ export function print(node, opts = {}) {
 	if (Array.isArray(node)) {
 		return print(
 			{
-				//@ts-expect-error
 				type: 'Program',
 				body: node,
 				sourceType: 'module'
@@ -41,7 +40,7 @@ export function print(node, opts = {}) {
 		multiline: false
 	};
 
-	handle(/** @type {TSESTree.Node} */ (/** @type {any} */ (node)), state);
+	handle(/** @type {TSESTree.Node} */ (node), state);
 
 	/** @typedef {[number, number, number, number]} Segment */
 


### PR DESCRIPTION
As of 1.3.0, `print` takes a `TSESTree.Node` as the first argument. This creates problems such as https://github.com/sveltejs/svelte/issues/14759, since it adds a dependency on `@typescript-eslint/types` which has a more recent minimum Node version than Svelte. It's also cumbersome in the case where you're dealing with normal `estree` nodes.

This PR loosens the types, and moves the offending package to `devDependencies`.