### PR TITLE
feat: support indexed access type

### DIFF
--- a/src/handlers.js
+++ b/src/handlers.js
@@ -556,6 +556,12 @@ function handle_type_annotation(node, state) {
 			state.commands.push(' : ');
 			handle_type_annotation(node.falseType, state);
 			break;
+		case 'TSIndexedAccessType':
+			handle_type_annotation(node.objectType, state);
+			state.commands.push('[');
+			handle_type_annotation(node.indexType, state);
+			state.commands.push(']');
+			break;
 		default:
 			throw new Error(`Not implemented type annotation ${node.type}`);
 	}

--- a/test/samples/ts-index-access-type/expected.ts
+++ b/test/samples/ts-index-access-type/expected.ts
@@ -1,0 +1,4 @@
+type A = { a: string; b: number };
+type B = A['b'];
+
+const c: A['b'] = 1;

--- a/test/samples/ts-index-access-type/expected.ts.map
+++ b/test/samples/ts-index-access-type/expected.ts.map
@@ -1,0 +1,11 @@
+{
+  "version": 3,
+  "names": [],
+  "sources": [
+    "input.js"
+  ],
+  "sourcesContent": [
+    "type A = { a: string; b: number };\ntype B = A['b'];\n\nconst c: A['b'] = 1;\n"
+  ],
+  "mappings": "KAAK,CAAC,KAAK,CAAC,UAAU,CAAC;KAClB,CAAC,GAAG,CAAC,CAAC,GAAG;;MAER,CAAS,EAAN,CAAC,CAAC,GAAG,IAAI,CAAC"
+}

--- a/test/samples/ts-index-access-type/input.ts
+++ b/test/samples/ts-index-access-type/input.ts
@@ -1,0 +1,4 @@
+type A = { a: string; b: number };
+type B = A['b'];
+
+const c: A['b'] = 1;


### PR DESCRIPTION
Relevant for https://github.com/sveltejs/cli/pull/380

Support's stuff like this:
```ts
type B = A['b'];
const c: A['b'] = 1;
```